### PR TITLE
Resilience Improvements

### DIFF
--- a/roles/k8s/files/kubernetes_join_command.sh
+++ b/roles/k8s/files/kubernetes_join_command.sh
@@ -1,0 +1,2 @@
+kubeadm reset -f
+{{ kubernetes_join_command.stdout }}

--- a/roles/k8s/tasks/generic.yml
+++ b/roles/k8s/tasks/generic.yml
@@ -26,6 +26,9 @@
 - name: Apply New Sysctl Options
   command: sysctl --system
 
+- name: Clean Kubernete Environment
+  shell: "kubeadm reset -f"
+
 - name: Start & Enable Containerd
   service: name=containerd state=restarted enabled=yes
 

--- a/roles/k8s/tasks/master.yml
+++ b/roles/k8s/tasks/master.yml
@@ -34,29 +34,18 @@
     path: /tmp/calico.yaml
     state: absent
 
-- name: Check for Local Join Command
-  stat:
-    path: "files/{{ cluster_name }}_kubernetes_join_command.sh"
-  register: join_cmd_exists
-  delegate_to: localhost
-  run_once: true
-
 - name: Get the Local Join Command
   become: yes
   become_user: "{{ default_username }}"
-  shell: kubeadm token create  --print-join-command
+  shell: kubeadm token create --print-join-command --ttl 0
   register: kubernetes_join_command
   run_once: true
-  delegate_to: localhost
-  when: not join_cmd_exists.stat.exists
 
 - name: Write Local Join Command
-  copy:
-    content: "{{ kubernetes_join_command.stdout }}"
+  template:
+    src: files/kubernetes_join_command.sh
     dest: "files/{{ cluster_name }}_kubernetes_join_command.sh"
   run_once: true
-  delegate_to: localhost
-  when: not join_cmd_exists.stat.exists
 
 - name: Trust Tunnel Interface Traffic
   firewalld:

--- a/roles/k8s/tasks/master.yml
+++ b/roles/k8s/tasks/master.yml
@@ -46,6 +46,7 @@
     src: files/kubernetes_join_command.sh
     dest: "files/{{ cluster_name }}_kubernetes_join_command.sh"
   run_once: true
+  delegate_to: localhost
 
 - name: Trust Tunnel Interface Traffic
   firewalld:

--- a/roles/k8s/tasks/worker.yml
+++ b/roles/k8s/tasks/worker.yml
@@ -8,6 +8,10 @@
 
 - name: Join the Worker Node to the cluster.
   command: bash /tmp/kubernetes_join_command.sh
+  register: output
+  retries: 5
+  delay: 30
+  until: output.rc == 0
 
 - name: Tidy Up
   file:


### PR DESCRIPTION
This PR addresses issues with rerunning the playbook. Previously, it would fail on reruns regardless of if the master failed to setup or if the node join failed.

It's now presumed that rerunning is a **destructive** action so the kubernetes installations are reset. 

Also, some other enhancements have been added, such as, setting a longer (infinite) TTL on the kubernetes join command (so nodes can be added to a cluster at a later date without needing to do some rerunning on the master - perhaps this could be replaced with a pre-hook to generate a join command)